### PR TITLE
Fix issue causing modifiers placed on orange notes to stop orange notes from rendering at all

### DIFF
--- a/ChartPreview/Source/Midi/Utils/InstrumentMapper.h
+++ b/ChartPreview/Source/Midi/Utils/InstrumentMapper.h
@@ -234,5 +234,5 @@ public:
     }
 
 private:
-    static constexpr size_t LANE_COUNT = 5;  // Max lanes (0-4)
+    static constexpr size_t LANE_COUNT = 7;  // Number of playable lanes (0-6)
 };


### PR DESCRIPTION
There are 7 lanes, but LANE_COUNT was set to 5. This was causing issues where combining a modifier with an orange note would cause the note to just disappear and not render, as that was essentially flagging orange as an invalid/unknown pitch.

It may also make sense to just not have LANE_COUNT defined in two places, since it also exists in Utils.h too, but i didn't make that fix here.